### PR TITLE
Remove "allow_quick_edit" flag from Config Table.

### DIFF
--- a/migrations/v10x/beta1.php
+++ b/migrations/v10x/beta1.php
@@ -56,6 +56,7 @@ class beta1 extends \phpbb\db\migration\migration
 	public function revert_data()
 	{
 		return array(
+			array('config.remove', array('allow_quick_edit')),
 			array('custom', array(array($this, 'revert_forum_flags'))),
 		);
 	}


### PR DESCRIPTION
This is Required coz the code on line `19` caused to skip `update_schema` when EXT was previously installed.

How to reproduce this bug:
1. Fresh Install this EXT. [Skip, if already Fresh Installed]
2. Disable the EXT.
3. Delete the Data. [At this stage, `allow_quick_edit` flag is not removed]
4. then enable this EXT. [At this stage, Migration skip's the `update_schema` due to `allow_quick_edit` flag]
5. then `Board Features` > Enable Quick Edit in all forums.
6. Get's an SQL Error.[Due to out of range coz `forum_flags` is `'TINT:4'`]
7. Need to manually fix by changing the Data type to `'UINT'`.

Best Regards. :smile: